### PR TITLE
Favour module key of package.json as the best indicator of esm file

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -182,8 +182,8 @@ function importExportVisitor(
                 `Unexpected empty package.json content in import "${importPath}", path "${packagePath}"`,
               );
             }
-            const pkgMain = (pkgInfo.exports ??
-              pkgInfo.module ??
+            const pkgMain = (pkgInfo.module ??
+              pkgInfo.exports ??
               pkgInfo.main ??
               indexJS) as string;
 


### PR DESCRIPTION
When the module key is set in a package.json then the library has explicitly set an esm module, so we should favour that over the other package.json keys we look at.