### PR TITLE
fix(transform): add check for virtual nodes before reading module spe…

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,9 +49,9 @@
     "mgenware-tsconfig-node": "^14.0.2",
     "mocha": "^10.2.0",
     "source-map-support": "^0.5.21",
-    "typescript": "^4.9.4"
+    "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "typescript": "^4.9.0"
+    "typescript": "^5.4.2"
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -38,7 +38,7 @@ function importExportVisitor(
 
   const visitor: ts.Visitor = (node: ts.Node): ts.Node => {
     let importPath = '';
-    if ((ts.isImportDeclaration(node) || ts.isExportDeclaration(node)) && node.moduleSpecifier) {
+    if ((ts.isImportDeclaration(node) || ts.isExportDeclaration(node)) && node.moduleSpecifier && ts.positionIsSynthesized(node.pos) === false && ts.positionIsSynthesized(node.end) == false) {
       const importPathWithQuotes = node.moduleSpecifier.getText(sf);
       importPath = importPathWithQuotes.substr(1, importPathWithQuotes.length - 2);
     } else if (helper.isDynamicImport(node)) {


### PR DESCRIPTION
…cifier (#9)

Added a check for virtual nodes generated by TypeScript for import helpers when `importHelpers: true` is set in `tsconfig.json`. These virtual nodes have start and end positions of `-1`, causing an error when attempting to read the module specifier using `getText(sf)` in `main.ts`. The fix prevents the exception by verifying if the node is virtual before accessing its text.

Closes #9